### PR TITLE
docker build updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN R -e "devtools::install_github('RfastOfficial/Rfast', dependencies=TRUE); li
 
 # Install reconstructR R package
 COPY . /opt/reconstructR
-RUN R -e "devtools::install_local("/opt/reconstructR", dependencies=TRUE, upgrade='never'); library(reconstructR)"
+RUN R -e "devtools::install_local('/opt/reconstructR', dependencies=TRUE, upgrade='never'); library(reconstructR)"
 
 # Bash prompt
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
 
 # install all desired packages
 RUN apt-get -y -qq install \
-    less nano vim git wget curl jq zstd parallel locales \
+    less nano vim git wget curl jq zstd pigz parallel locales \
     gnupg libssl-dev libcurl4-openssl-dev \
     libgsl-dev libxml2 libxml2-dev \
     imagemagick libmagick++-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,13 @@ LABEL maintainer "Daniel Park <dpark@broadinstitute.org>"
 # non-interactive session just for build
 ARG DEBIAN_FRONTEND=noninteractive
 
-# update apt database and install R apt repo
+# update apt database and install R apt repo; install all desired packages
 RUN apt-get update && \
   apt-get -y -qq install software-properties-common && \
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
   add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/' && \
-  apt-get update
-
-# install all desired packages
-RUN apt-get -y -qq install \
+  apt-get update && \
+  apt-get -y -qq install \
     less nano vim git wget curl jq zstd pigz parallel locales \
     gnupg libssl-dev libcurl4-openssl-dev \
     libgsl-dev libxml2 libxml2-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,9 @@ RUN R -e "for (lib in c( 'LaplacesDemon', 'kmer', 'phylogram', 'aphid', 'insect'
 # Rfast in CRAN is broken, install from github
 RUN R -e "devtools::install_github('RfastOfficial/Rfast', dependencies=TRUE); library(Rfast)"
 
-# Install reconstructR R package -- invalidate cache any time github main branch updates
-ADD https://api.github.com/repos/broadinstitute/reconstructR/git/refs/heads/main version.json
-RUN R -e "devtools::install_github('broadinstitute/reconstructR', dependencies=TRUE, upgrade='never'); library(reconstructR)"
+# Install reconstructR R package
+COPY . /opt/reconstructR
+RUN R -e "devtools::install_local("/opt/reconstructR", dependencies=TRUE, upgrade='never'); library(reconstructR)"
 
 # Bash prompt
 CMD ["/bin/bash"]

--- a/scripts/cp_and_decompress.sh
+++ b/scripts/cp_and_decompress.sh
@@ -4,9 +4,9 @@ INFILE=$1
 OUTFILE=$2
 
 if [[ $INFILE == *.gz ]]; then
-  pigz -dc $INFILE > $OUTFILE
+    pigz -dc $INFILE > $OUTFILE
 elif [[ $INFILE == *.zst ]]; then
-  zstd -d $INFILE -o $OUTFILE
+    zstd -d $INFILE -o $OUTFILE
 else
-  cp $INFILE $OUTFILE
+    cp $INFILE $OUTFILE
 fi

--- a/scripts/cp_and_decompress.sh
+++ b/scripts/cp_and_decompress.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+INFILE=$1
+OUTFILE=$2
+
+if [[ $INFILE == *.gz ]]; then
+  pigz -dc $INFILE > $OUTFILE
+elif [[ $INFILE == *.zst ]]; then
+  zstd -d $INFILE -o $OUTFILE
+else
+  cp $INFILE $OUTFILE
+fi

--- a/scripts/mcp_and_decompress.sh
+++ b/scripts/mcp_and_decompress.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+INFILES=${@:1:$#-1}
+OUTDIR=${@:$#}
+
+for INFILE in $INFILES; do
+    if [[ $INFILE == *.gz ]]; then
+        OUTFNAME=$(basename $INFILE .gz)
+        pigz -dc $INFILE > "$OUTDIR/$OUTFNAME"
+    elif [[ $INFILE == *.zst ]]; then
+        OUTFNAME=$(basename $INFILE .zst)
+        zstd -d $INFILE -o "$OUTDIR/$OUTFNAME"
+    else
+        OUTFNAME=$(basename $INFILE)
+        cp $INFILE "$OUTDIR/$OUTFNAME"
+    fi
+done


### PR DESCRIPTION
This PR:
 - fixes certain rare out-of-sync scenarios in the Docker build layers
 - adds some utility shell scripts for use in WDL (mostly having to do with auto-handling of file compression)
 - changes the install of `reconstructR` from `install_github` (which was always pulling from the `main` branch on github) to `install_local` (which will always pull the exact R code that is associated with this particular build / branch / commit)